### PR TITLE
Populate placeholders for fontName and fontPath when generating Sass.

### DIFF
--- a/src/gulp-font-icons.js
+++ b/src/gulp-font-icons.js
@@ -59,6 +59,8 @@ export function generateIconSass(glyphs) {
       }),
       className: config.className,
       comment: config.comment,
+      fontName: config.options.fontName,
+      fontPath: config.fontPath,
     },
   });
 


### PR DESCRIPTION
Fix for empty font-family and missing font-path in generated sass file.
